### PR TITLE
Don't use auto-generated classes for selectors

### DIFF
--- a/reverseNames.js
+++ b/reverseNames.js
@@ -1,20 +1,26 @@
 const checkForNames = () => {
-  // Grabs all of the name elements with the class name "cS7aqe NkoVdd"
-  let nameDivs = document.getElementsByClassName("cS7aqe NkoVdd");
-  // Checks the length of the collection
-  if (nameDivs.length > 0) {
-    // Reverses the names
-    alreadyDone = true;
-    for (let i = 0; i < nameDivs.length; i++) {
-      let name = nameDivs[i].innerText;
-      if (!name.includes(',')) {
-        let splitName = name.split(" ");
-        if (splitName.length == 2) {
-          nameDivs[i].innerText = splitName[1] + ", " + splitName[0];
-        } else continue;
+  // get the Meeting details > Participants container node
+  const participantsContainer = document.querySelector('[aria-label="Participants"]');
+  
+  // convert the HTMLCollection to an iterable
+  const participantsElements = Array.from(participantsContainer.children ?? []);
+
+  participantsElements.forEach((participantElement) => {
+    // find the img element as it should be the previousSibling to the name container
+    const [imageElement] = participantElement.getElementsByTagName('img');
+    const nameContainer = imageElement?.nextSibling;
+    
+    if (nameContainer) {
+      // get the actual element that contains the participant's name
+      const [nameElement] = nameContainer.getElementsByTagName('span');
+                                          
+      if (nameElement) {
+        // cater for participants with more than 1 last name
+        const [fName, lName, ...names] = nameElement.textContent.split(' ');
+        nameElement.textContent = `${lName}${names.length ? ' ' + names.join(' ') : ''}, ${fName}`;
       }
     }
-  }
+  });
 };
 
 setInterval(checkForNames, 1500);


### PR DESCRIPTION
The classes used in Meet are auto-generated and are thus brittle and not ideal to use for selectors. This update to reverseNames instead relies on the structure of the page to target the participant names. Because the classes that were previously in use as selectors are no longer present,

I'm unsure if this targeted the names in the videos themselves or just simply the list of participants. If the former, this update won't fix anything; if the latter, this update should be a decent fix for now (until Google changes the document structure).